### PR TITLE
Remove old apache PID files

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+rm -f /var/run/apache2.pid
+
 # Start apache
 /usr/sbin/apache2 -D FOREGROUND


### PR DESCRIPTION
Otherwise restarting the docker image fails with an error.